### PR TITLE
Update the examples to use the new module lifting syntax

### DIFF
--- a/finally_tagless/finally_tagless.ml
+++ b/finally_tagless/finally_tagless.ml
@@ -34,7 +34,7 @@ end
 module S_sta : Symantics
   with type ('c, 'sv, 'dv) repr = 'dv
 = struct
-  open ^Pervasives
+  open ~Pervasives
   type ('c, 'sv, 'dv) repr = 'dv
   macro int x = x
   macro bool b = b

--- a/staged-streams/stream_combinators_s.ml
+++ b/staged-streams/stream_combinators_s.ml
@@ -47,7 +47,7 @@
   on the stream structure and internals.
  *)
 
-static (@@) = ^Pervasives.(@@)
+static (@@) = ~Pervasives.(@@)
 
 type card_t = AtMost1 | Many
 
@@ -224,7 +224,7 @@ macro take_raw   : int expr -> 'a st_stream -> 'a st_stream =
          card;
          (* For filter, we assume that is a dependent stream... *)
          term = (fun (nr,s) ->
-                 let (=) = ^Pervasives.(=) in
+                 let (=) = ~Pervasives.(=) in
                  if card = Many then << ! $nr > 0 && $(term s) >> else term s);
          step = (fun (nr,s) k -> step s (fun el -> k (nr,el)))}
       in Prod ({init},prod)

--- a/staged-streams/test.ml
+++ b/staged-streams/test.ml
@@ -1,6 +1,6 @@
 open Stream_combinators_s
 
-static (|>) = ^Pervasives.(|>)
+static (|>) = ~Pervasives.(|>)
 macro example () =
     of_arr << [| 0;1;2;3 |] >>
       |> filter (fun x   -> << $x mod 2 = 0 >>)


### PR DESCRIPTION
`^Pervasives` is now `~Pervasives`